### PR TITLE
Quickfix for slash in note names

### DIFF
--- a/itl_scrape.py
+++ b/itl_scrape.py
@@ -224,9 +224,15 @@ class itslearning_scraper():
         text = self.html2text.handle(str(text))
         fp = os.path.join(os.path.abspath(os.path.curdir), title)
         #convert to md?
-        with open(fp+".md", "wb") as note:
-            note.write(bytes(text.encode("utf-8")))
-            note.close()
+        try:
+            with open(fp+".md", "wb") as note:
+                note.write(bytes(text.encode("utf-8")))
+                note.close()
+        except FileNotFoundError:
+            if "/" in title:
+                print("File contains slash '%s'. Skipping" % title)
+            else:
+                print("File not found '%s'" % title)
 
     def find_files(self,folders):
         for link in folders.find_all('a'):


### PR DESCRIPTION
Very quick and dirty fix for handling `/` in note names. Simply skips the note gracefully rather than crashing and skipping the rest of the subject. 

Should probably be generalized somewhere else in the code. 